### PR TITLE
feat(worktrees): create worktree from remote branch or tag, optional project-name prefix

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -987,6 +987,11 @@
           "default": true,
           "description": "When force-pushing from GitStudio, use the safer --force-with-lease (which refuses to overwrite remote work you haven't seen) instead of a raw --force."
         },
+        "gitstudio.worktrees.prefixWithProjectName": {
+          "type": "boolean",
+          "default": false,
+          "description": "When creating a worktree, name its folder '<project>-<branch>' instead of just '<branch>', where '<project>' is the main repository's folder name (resolved from any linked worktree, so the prefix never compounds no matter where you create it)."
+        },
         "gitstudio.ai.provider": {
           "type": "string",
           "enum": [

--- a/apps/extension/src/views/branchActions.ts
+++ b/apps/extension/src/views/branchActions.ts
@@ -10,6 +10,7 @@ import {
   promptPick,
   type DialogChoice,
 } from "../ui/dialogs";
+import { worktreeFromRef } from "./worktreesView";
 
 // Branch / remote / tag context-menu actions for the Branches view. Each runs a
 // real git op via the GitContext provider methods, confirms destructive ops, and
@@ -457,7 +458,9 @@ export async function newBranchFrom(
   report(result, `Created ${name}`, refresh);
 }
 
-/** "Create worktree for this branch" — pick a folder, add a worktree on `ref`. */
+/** "Create worktree for this branch" — pick a folder, add a worktree on `ref`.
+ *  Delegates to the shared worktree flow so it can also create a new named
+ *  branch from this ref (including remote branches), from any current branch. */
 export async function createWorktreeForBranch(
   repos: RepoManager,
   arg: unknown,
@@ -468,36 +471,7 @@ export async function createWorktreeForBranch(
   if (!a || !ref) {
     return;
   }
-  const folders = await vscode.window.showOpenDialog({
-    canSelectFolders: true,
-    canSelectFiles: false,
-    canSelectMany: false,
-    openLabel: "Create Worktree Here",
-    title: `Pick a parent folder for the ${ref.name} worktree`,
-  });
-  const parent = folders?.[0];
-  if (!parent) {
-    return;
-  }
-  const leaf = ref.name.split("/").pop() ?? ref.name;
-  const target = vscode.Uri.joinPath(parent, leaf);
-  const result = await a.ctx.worktrees.add(target.fsPath, ref.name);
-  if (!result.ok) {
-    void vscode.window.showErrorMessage(
-      result.stderr.trim() || "GitStudio: worktree add failed.",
-    );
-    return;
-  }
-  refresh();
-  const open = await vscode.window.showInformationMessage(
-    `Created worktree for ${ref.name} at ${target.fsPath}`,
-    "Open in New Window",
-  );
-  if (open === "Open in New Window") {
-    await vscode.commands.executeCommand("vscode.openFolder", target, {
-      forceNewWindow: true,
-    });
-  }
+  await worktreeFromRef(repos, ref, refresh);
 }
 
 // ── Remote branch actions ────────────────────────────────────────────────────

--- a/apps/extension/src/views/worktreeRefs.ts
+++ b/apps/extension/src/views/worktreeRefs.ts
@@ -1,0 +1,89 @@
+import type { GitRef } from "@gitstudio/git-service/index";
+
+// Pure ref-name helpers for the worktree-create flow. Kept DOM- and vscode-free
+// so they're unit-testable, like the parser in git-service.
+
+/**
+ * The bare name of a branch a start point's upstream would be set from. For a
+ * remote-tracking ref `refs/remotes/origin/feature` this is "feature" (NOT
+ * "origin/feature"): git's `branch.autoSetupMerge=simple` compares the new
+ * branch's name to the remote branch's short name, so `-b feature … origin/feature`
+ * tracks while `-b my-experiment … origin/feature` must not.
+ */
+export function shortNameOf(startPoint: string): string | undefined {
+  if (startPoint.startsWith("refs/heads/")) {
+    return startPoint.slice("refs/heads/".length);
+  }
+  if (startPoint.startsWith("refs/remotes/")) {
+    return startPoint.slice("refs/remotes/".length).split("/").slice(1).join("/");
+  }
+  if (startPoint.startsWith("refs/tags/")) {
+    return startPoint.slice("refs/tags/".length);
+  }
+  return undefined;
+}
+
+/**
+ * The bare short name for `ref`, with git's disambiguating type prefix removed.
+ * When a local branch and a tag share a short name (git warns "refname 'v1.2'
+ * is ambiguous"), `%(refname:short)` returns the name with the type prefixed —
+ * "heads/v1.2" / "tags/v1.2" — and for remotes it can return "remotes/origin/x".
+ * Checking a branch out by name or reconstructing `refs/<type>/<name>` needs the
+ * prefix handled: an un-stripped "heads/v1.2" silently detaches, a double
+ * prefix ("refs/tags/tags/v1.2") is a fatal.
+ *
+ * Derived from `fullName` when present (authoritative, never false-strips): a
+ * genuine branch named "heads/x" and a collision-prefixed name are string-
+ * identical, so name-based stripping alone would corrupt one of them. Only when
+ * `fullName` is absent (branch-menu webview, before worktreeFromRef re-resolves
+ * it) do we fall back to stripping a single type prefix from the short name.
+ */
+export function bareName(ref: GitRef): string {
+  if (ref.fullName) {
+    switch (ref.type) {
+      case "head":
+        return ref.fullName.slice("refs/heads/".length);
+      case "remote":
+        return ref.fullName.slice("refs/remotes/".length);
+      case "tag":
+        return ref.fullName.slice("refs/tags/".length);
+      default:
+        return ref.fullName;
+    }
+  }
+  switch (ref.type) {
+    case "head":
+      return ref.name.replace(/^heads\//, "");
+    case "remote":
+      return ref.name.replace(/^remotes\//, "");
+    case "tag":
+      return ref.name.replace(/^tags\//, "");
+    default:
+      return ref.name;
+  }
+}
+
+/**
+ * The fully-qualified ref to start a new branch from. The Worktrees view builds
+ * its refs from `listRefs()`, so `fullName` is set; the branch menu's webview
+ * only sends `name` + `type` (no `fullName`). Reconstruct the FQN here so both
+ * create paths pass an identical start point — otherwise the branch-menu path
+ * falls back to "from HEAD", silently skipping the upstream tracking that the
+ * Worktrees-view path sets up for a remote start point.
+ */
+export function startPointOf(ref: GitRef): string | undefined {
+  if (ref.fullName) {
+    return ref.fullName;
+  }
+  const name = bareName(ref);
+  switch (ref.type) {
+    case "head":
+      return `refs/heads/${name}`;
+    case "remote":
+      return `refs/remotes/${name}`;
+    case "tag":
+      return `refs/tags/${name}`;
+    default:
+      return undefined;
+  }
+}

--- a/apps/extension/src/views/worktreesView.ts
+++ b/apps/extension/src/views/worktreesView.ts
@@ -1,6 +1,12 @@
 import * as vscode from "vscode";
-import { promptConfirm, promptInput, promptPick } from "../ui/dialogs";
+import {
+  promptConfirm,
+  promptInput,
+  promptPick,
+  type DialogChoice,
+} from "../ui/dialogs";
 import { homedir } from "node:os";
+import * as path from "node:path";
 import type { WorktreeEntry, GitRef } from "@gitstudio/git-service/index";
 import type { RepoManager, RepoEntry } from "../git/repoManager";
 
@@ -330,7 +336,7 @@ export async function openWorktree(node: WorktreeNode): Promise<void> {
   });
 }
 
-/** `gitstudio.worktree.add` — pick a branch (or name a new one) + a folder. */
+/** `gitstudio.worktree.add` — pick a ref (branch/remote/tag, or a new one) + a folder. */
 export async function addWorktree(
   repos: RepoManager,
   refresh: () => void,
@@ -346,38 +352,51 @@ export async function addWorktree(
   } catch {
     // proceed with new-branch only
   }
-  const localBranches = refs.filter((r) => r.type === "head");
 
-  // A sentinel id no branch can collide with: git forbids ":" in a ref name.
+  // A sentinel id no ref can collide with: git forbids ":" in a ref name.
   const NEW = "gitstudio:new-branch";
+
+  // Local branches, remote branches, and tags — so you can base a worktree on
+  // origin/main without first checking it out anywhere. Keyed by the FULL ref:
+  // a local branch and a tag can legally share a short name (git warns "refname
+  // 'v1.2' is ambiguous"), and keying by the short name would silently resolve
+  // the picked row to whichever ref git listed last. Labels stay short.
+  const byId = new Map<string, GitRef>();
+  const choices: DialogChoice[] = [
+    {
+      id: NEW,
+      label: "New branch…",
+      icon: "add",
+      description: "Create a new branch from the current HEAD.",
+    },
+  ];
+  for (const r of refs) {
+    if (r.type === "stash") {
+      continue;
+    }
+    const key = r.fullName ?? r.name;
+    byId.set(key, r);
+    choices.push({
+      id: key,
+      label: r.name,
+      icon: r.type === "head" ? "git-branch" : r.type === "remote" ? "cloud" : "tag",
+      detail: r.sha.slice(0, 7),
+    });
+  }
+
   const picked = await promptPick({
-    title: "New worktree — pick a branch",
-    hint: "Which branch should be checked out in the new worktree?",
-    choices: [
-      {
-        id: NEW,
-        label: "New branch…",
-        icon: "add",
-        description: "Create a new branch in the worktree.",
-      },
-      ...localBranches.map((r) => ({
-        id: r.name,
-        label: r.name,
-        icon: "git-branch",
-        detail: r.sha.slice(0, 7),
-      })),
-    ],
+    title: "New worktree — pick a ref",
+    hint: "What should the new worktree be based on?",
+    choices,
   });
   if (!picked) {
     return;
   }
 
-  let ref: string;
-  let newBranch = false;
   if (picked === NEW) {
     const name = await promptInput({
       title: "New worktree branch",
-      hint: "The branch is created and checked out in the new worktree.",
+      hint: "The branch is created at the current HEAD and checked out in the new worktree.",
       placeholder: "feature/worktree",
       confirmLabel: "Continue",
       validate: "refName",
@@ -385,12 +404,188 @@ export async function addWorktree(
     if (!name) {
       return;
     }
-    ref = name;
-    newBranch = true;
-  } else {
-    ref = picked;
+    await pickFolderAndCreate(
+      a,
+      { branchName: name, newBranch: true },
+      refresh,
+    );
+    return;
   }
 
+  const ref = byId.get(picked);
+  if (!ref) {
+    return;
+  }
+  await worktreeFromRef(repos, ref, refresh);
+}
+
+/**
+ * Shared "create a worktree from an existing ref" flow — used by the Worktrees
+ * view's "New Worktree" (after picking a ref) and by the branch menu's
+ * "New Worktree from '…'". Works for local branches, remote branches, and tags,
+ * and never requires switching off the current branch.
+ */
+export async function worktreeFromRef(
+  repos: RepoManager,
+  ref: GitRef,
+  refresh: () => void,
+): Promise<void> {
+  const a = active(repos);
+  if (!a) {
+    return;
+  }
+
+  // The branch-menu webview sends name + type only (no fullName). Re-resolve the
+  // authoritative fullName from listRefs() so the start point and the direct
+  // checkout are exact even when git disambiguated the short name: a genuine
+  // branch named "heads/x" and a collision-prefixed name are string-identical,
+  // so name-based stripping alone would mis-strip one of them.
+  let resolved = ref;
+  if (!ref.fullName) {
+    try {
+      const refs = await a.ctx.refs.listRefs();
+      resolved =
+        refs.find((r) => r.type === ref.type && r.name === ref.name) ?? ref;
+    } catch {
+      // keep the webview ref
+    }
+  }
+
+  const isLocal = resolved.type === "head";
+  const mode = await promptPick({
+    title: `Worktree from '${resolved.name}'`,
+    hint: "Check it out directly, or as a new named branch?",
+    choices: [
+      {
+        id: "direct",
+        label: isLocal ? resolved.name : `${resolved.name} (detached)`,
+        icon: isLocal ? "git-branch" : "git-commit",
+        description: isLocal
+          ? `Check out the existing local branch ${resolved.name}.`
+          : `Check out ${resolved.name} as a detached HEAD.`,
+      },
+      {
+        id: "new",
+        label: "New branch…",
+        icon: "add",
+        description: `Create a new local branch starting from ${resolved.name}.`,
+      },
+    ],
+  });
+  if (!mode) {
+    return;
+  }
+
+  if (mode === "direct") {
+    // Local branches attach via their short name; a full refs/heads/… would
+    // silently detach. Remote/tag refs must detach and need the full ref so a
+    // tag sharing a branch's short name can't resolve ambiguously — startPointOf
+    // also reconstructs the full ref for the branch-menu path, which only sends
+    // name + type. bareName strips git's collision disambiguator ("heads/x").
+    const directRef =
+      resolved.type === "head"
+        ? bareName(resolved)
+        : (startPointOf(resolved) ?? bareName(resolved));
+    await pickFolderAndCreate(
+      a,
+      { branchName: directRef, newBranch: false },
+      refresh,
+    );
+    return;
+  }
+
+  const name = await promptInput({
+    title: "New worktree branch",
+    hint: `A new local branch is created from ${resolved.name} and checked out in the new worktree.`,
+    placeholder: "feature/worktree",
+    confirmLabel: "Continue",
+    validate: "refName",
+  });
+  if (!name) {
+    return;
+  }
+  await pickFolderAndCreate(
+    a,
+    { branchName: name, newBranch: true, startPoint: startPointOf(resolved) },
+    refresh,
+  );
+}
+
+/**
+ * The bare short name for `ref`, with git's disambiguating type prefix removed.
+ * When a local branch and a tag share a short name (git warns "refname 'v1.2'
+ * is ambiguous"), `%(refname:short)` returns the name with the type prefixed —
+ * "heads/v1.2" / "tags/v1.2" — and for remotes it can return "remotes/origin/x".
+ * Checking a branch out by name or reconstructing `refs/<type>/<name>` needs the
+ * prefix handled: an un-stripped "heads/v1.2" silently detaches, a double
+ * prefix ("refs/tags/tags/v1.2") is a fatal.
+ *
+ * Derived from `fullName` when present (authoritative, never false-strips): a
+ * genuine branch named "heads/x" and a collision-prefixed name are string-
+ * identical, so name-based stripping alone would corrupt one of them. Only when
+ * `fullName` is absent (branch-menu webview, before worktreeFromRef re-resolves
+ * it) do we fall back to stripping a single type prefix from the short name.
+ */
+function bareName(ref: GitRef): string {
+  if (ref.fullName) {
+    switch (ref.type) {
+      case "head":
+        return ref.fullName.slice("refs/heads/".length);
+      case "remote":
+        return ref.fullName.slice("refs/remotes/".length);
+      case "tag":
+        return ref.fullName.slice("refs/tags/".length);
+      default:
+        return ref.fullName;
+    }
+  }
+  switch (ref.type) {
+    case "head":
+      return ref.name.replace(/^heads\//, "");
+    case "remote":
+      return ref.name.replace(/^remotes\//, "");
+    case "tag":
+      return ref.name.replace(/^tags\//, "");
+    default:
+      return ref.name;
+  }
+}
+
+/**
+ * The fully-qualified ref to start a new branch from. The Worktrees view builds
+ * its refs from `listRefs()`, so `fullName` is set; the branch menu's webview
+ * only sends `name` + `type` (no `fullName`). Reconstruct the FQN here so both
+ * create paths pass an identical start point — otherwise the branch-menu path
+ * falls back to "from HEAD", silently skipping the upstream tracking that the
+ * Worktrees-view path sets up for a remote start point.
+ */
+function startPointOf(ref: GitRef): string | undefined {
+  if (ref.fullName) {
+    return ref.fullName;
+  }
+  const name = bareName(ref);
+  switch (ref.type) {
+    case "head":
+      return `refs/heads/${name}`;
+    case "remote":
+      return `refs/remotes/${name}`;
+    case "tag":
+      return `refs/tags/${name}`;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Pick a parent folder, then add the worktree in a subfolder named after the
+ * branch's last segment and report the outcome. Shared by every create route so
+ * the folder/dir-naming logic stays in exactly one place.
+ */
+async function pickFolderAndCreate(
+  a: RepoEntry,
+  opts: { branchName: string; newBranch: boolean; startPoint?: string },
+  refresh: () => void,
+): Promise<void> {
   const folders = await vscode.window.showOpenDialog({
     canSelectFolders: true,
     canSelectFiles: false,
@@ -402,11 +597,30 @@ export async function addWorktree(
   if (!parent) {
     return;
   }
-  // Place the worktree in a subfolder named after the ref's last segment.
-  const leaf = ref.split("/").pop() ?? ref;
-  const target = vscode.Uri.joinPath(parent, leaf);
+  // Place the worktree in a subfolder named after the ref's last segment. When
+  // gitstudio.worktrees.prefixWithProjectName is on, prefix it with the MAIN
+  // repository's folder name — resolved from the common git dir, so the prefix
+  // is stable no matter which (possibly linked) worktree initiated the add.
+  const leaf = opts.branchName.split("/").pop() ?? opts.branchName;
+  let dirName = leaf;
+  const prefixEnabled = vscode.workspace
+    .getConfiguration("gitstudio")
+    .get<boolean>("worktrees.prefixWithProjectName", false);
+  if (prefixEnabled) {
+    const mainRoot = await a.ctx.worktrees.mainRoot();
+    if (mainRoot) {
+      const project = path.basename(mainRoot);
+      if (project) {
+        dirName = `${project}-${leaf}`;
+      }
+    }
+  }
+  const target = vscode.Uri.joinPath(parent, dirName);
 
-  const result = await a.ctx.worktrees.add(target.fsPath, ref, { newBranch });
+  const result = await a.ctx.worktrees.add(target.fsPath, opts.branchName, {
+    newBranch: opts.newBranch,
+    startPoint: opts.startPoint,
+  });
   if (!result.ok) {
     void vscode.window.showErrorMessage(
       result.stderr.trim() || "GitStudio: worktree add failed.",

--- a/apps/extension/src/views/worktreesView.ts
+++ b/apps/extension/src/views/worktreesView.ts
@@ -9,6 +9,7 @@ import { homedir } from "node:os";
 import * as path from "node:path";
 import type { WorktreeEntry, GitRef } from "@gitstudio/git-service/index";
 import type { RepoManager, RepoEntry } from "../git/repoManager";
+import { bareName, shortNameOf, startPointOf } from "./worktreeRefs";
 
 // The Worktrees pillar — also absent from free VS Code. Each row is a linked (or
 // the main) worktree; actions cover open / add / remove / lock / unlock / prune.
@@ -371,7 +372,10 @@ export async function addWorktree(
     },
   ];
   for (const r of refs) {
-    if (r.type === "stash") {
+    // stash is not a worktree ref; "/HEAD" (origin/HEAD) is a symbolic pointer
+    // to the remote's default branch and checking it out detaches at whatever
+    // it points to — never offer it.
+    if (r.type === "stash" || r.name.endsWith("/HEAD")) {
       continue;
     }
     const key = r.fullName ?? r.name;
@@ -504,76 +508,23 @@ export async function worktreeFromRef(
   if (!name) {
     return;
   }
+
+  const startPoint = startPointOf(resolved);
+  // simple upstream semantics: track only when the new branch's name matches
+  // the start point's short name. A differently-named branch would otherwise
+  // auto-track the remote under git's default branch.autoSetupMerge, and
+  // GitStudio's push then targets that remote branch.
+  const short = startPoint ? shortNameOf(startPoint) : undefined;
   await pickFolderAndCreate(
     a,
-    { branchName: name, newBranch: true, startPoint: startPointOf(resolved) },
+    {
+      branchName: name,
+      newBranch: true,
+      startPoint,
+      noTrack: !!startPoint && short !== undefined && name !== short,
+    },
     refresh,
   );
-}
-
-/**
- * The bare short name for `ref`, with git's disambiguating type prefix removed.
- * When a local branch and a tag share a short name (git warns "refname 'v1.2'
- * is ambiguous"), `%(refname:short)` returns the name with the type prefixed —
- * "heads/v1.2" / "tags/v1.2" — and for remotes it can return "remotes/origin/x".
- * Checking a branch out by name or reconstructing `refs/<type>/<name>` needs the
- * prefix handled: an un-stripped "heads/v1.2" silently detaches, a double
- * prefix ("refs/tags/tags/v1.2") is a fatal.
- *
- * Derived from `fullName` when present (authoritative, never false-strips): a
- * genuine branch named "heads/x" and a collision-prefixed name are string-
- * identical, so name-based stripping alone would corrupt one of them. Only when
- * `fullName` is absent (branch-menu webview, before worktreeFromRef re-resolves
- * it) do we fall back to stripping a single type prefix from the short name.
- */
-function bareName(ref: GitRef): string {
-  if (ref.fullName) {
-    switch (ref.type) {
-      case "head":
-        return ref.fullName.slice("refs/heads/".length);
-      case "remote":
-        return ref.fullName.slice("refs/remotes/".length);
-      case "tag":
-        return ref.fullName.slice("refs/tags/".length);
-      default:
-        return ref.fullName;
-    }
-  }
-  switch (ref.type) {
-    case "head":
-      return ref.name.replace(/^heads\//, "");
-    case "remote":
-      return ref.name.replace(/^remotes\//, "");
-    case "tag":
-      return ref.name.replace(/^tags\//, "");
-    default:
-      return ref.name;
-  }
-}
-
-/**
- * The fully-qualified ref to start a new branch from. The Worktrees view builds
- * its refs from `listRefs()`, so `fullName` is set; the branch menu's webview
- * only sends `name` + `type` (no `fullName`). Reconstruct the FQN here so both
- * create paths pass an identical start point — otherwise the branch-menu path
- * falls back to "from HEAD", silently skipping the upstream tracking that the
- * Worktrees-view path sets up for a remote start point.
- */
-function startPointOf(ref: GitRef): string | undefined {
-  if (ref.fullName) {
-    return ref.fullName;
-  }
-  const name = bareName(ref);
-  switch (ref.type) {
-    case "head":
-      return `refs/heads/${name}`;
-    case "remote":
-      return `refs/remotes/${name}`;
-    case "tag":
-      return `refs/tags/${name}`;
-    default:
-      return undefined;
-  }
 }
 
 /**
@@ -583,7 +534,12 @@ function startPointOf(ref: GitRef): string | undefined {
  */
 async function pickFolderAndCreate(
   a: RepoEntry,
-  opts: { branchName: string; newBranch: boolean; startPoint?: string },
+  opts: {
+    branchName: string;
+    newBranch: boolean;
+    startPoint?: string;
+    noTrack?: boolean;
+  },
   refresh: () => void,
 ): Promise<void> {
   const folders = await vscode.window.showOpenDialog({
@@ -599,8 +555,9 @@ async function pickFolderAndCreate(
   }
   // Place the worktree in a subfolder named after the ref's last segment. When
   // gitstudio.worktrees.prefixWithProjectName is on, prefix it with the MAIN
-  // repository's folder name — resolved from the common git dir, so the prefix
-  // is stable no matter which (possibly linked) worktree initiated the add.
+  // repository's folder name — resolved from `git worktree list` (whose first
+  // entry is always the main checkout), so the prefix is stable no matter which
+  // (possibly linked) worktree initiated the add.
   const leaf = opts.branchName.split("/").pop() ?? opts.branchName;
   let dirName = leaf;
   const prefixEnabled = vscode.workspace
@@ -620,6 +577,7 @@ async function pickFolderAndCreate(
   const result = await a.ctx.worktrees.add(target.fsPath, opts.branchName, {
     newBranch: opts.newBranch,
     startPoint: opts.startPoint,
+    noTrack: opts.noTrack,
   });
   if (!result.ok) {
     void vscode.window.showErrorMessage(

--- a/apps/extension/test/worktreeRefs.test.ts
+++ b/apps/extension/test/worktreeRefs.test.ts
@@ -1,0 +1,89 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  bareName,
+  shortNameOf,
+  startPointOf,
+} from "../src/views/worktreeRefs";
+import type { GitRef } from "@gitstudio/git-service/index";
+
+// `fullName` is typed required but the branch-menu webview omits it (it sends
+// name + type only), so the no-fullName paths are real and tested here too.
+function ref(
+  type: GitRef["type"],
+  name: string,
+  fullName: string | undefined,
+): GitRef {
+  return { type, name, fullName: fullName ?? "", sha: "abc1234", isCurrent: false };
+}
+
+// ── bareName ────────────────────────────────────────────────────────────────
+
+test("bareName strips one type prefix from a full name", () => {
+  assert.equal(bareName(ref("head", "v1.2", "refs/heads/v1.2")), "v1.2");
+  assert.equal(
+    bareName(ref("remote", "origin/main", "refs/remotes/origin/main")),
+    "origin/main",
+  );
+  assert.equal(bareName(ref("tag", "v1.2", "refs/tags/v1.2")), "v1.2");
+});
+
+test("bareName does NOT strip a genuine 'heads/' branch name", () => {
+  // A genuine branch named "heads/x" and git's collision-disambiguated
+  // "heads/v1.2" are string-identical at the name level — only the fullName
+  // tells them apart, and it never false-strips.
+  assert.equal(bareName(ref("head", "heads/x", "refs/heads/heads/x")), "heads/x");
+  assert.equal(
+    bareName(ref("head", "heads/v1.2", "refs/heads/v1.2")),
+    "v1.2",
+  );
+  assert.equal(bareName(ref("tag", "tags/v1.2", "refs/tags/tags/v1.2")), "tags/v1.2");
+});
+
+test("bareName falls back to stripping the short-name prefix when fullName is absent", () => {
+  assert.equal(bareName(ref("head", "heads/v1.2", undefined)), "v1.2");
+  assert.equal(bareName(ref("head", "v1.2", undefined)), "v1.2");
+  assert.equal(bareName(ref("remote", "remotes/origin/x", undefined)), "origin/x");
+  assert.equal(bareName(ref("remote", "origin/x", undefined)), "origin/x");
+  assert.equal(bareName(ref("tag", "tags/v1.2", undefined)), "v1.2");
+});
+
+// ── startPointOf ────────────────────────────────────────────────────────────
+
+test("startPointOf returns the full name when present", () => {
+  assert.equal(
+    startPointOf(ref("remote", "origin/main", "refs/remotes/origin/main")),
+    "refs/remotes/origin/main",
+  );
+});
+
+test("startPointOf reconstructs the full name when absent", () => {
+  assert.equal(startPointOf(ref("head", "main", undefined)), "refs/heads/main");
+  assert.equal(
+    startPointOf(ref("remote", "origin/main", undefined)),
+    "refs/remotes/origin/main",
+  );
+  assert.equal(startPointOf(ref("tag", "v1.2", undefined)), "refs/tags/v1.2");
+});
+
+test("startPointOf returns undefined for an unknown type", () => {
+  assert.equal(startPointOf(ref("stash", "stash@{0}", undefined)), undefined);
+});
+
+// ── shortNameOf ─────────────────────────────────────────────────────────────
+
+test("shortNameOf yields the name git's simple autoSetupMerge compares against", () => {
+  assert.equal(shortNameOf("refs/heads/main"), "main");
+  // origin/feature → feature: `-b feature … origin/feature` tracks, anything
+  // else must not.
+  assert.equal(shortNameOf("refs/remotes/origin/feature"), "feature");
+  assert.equal(shortNameOf("refs/tags/v1.2"), "v1.2");
+});
+
+test("shortNameOf keeps nested remote paths beyond the remote name", () => {
+  assert.equal(shortNameOf("refs/remotes/origin/deep/x"), "deep/x");
+});
+
+test("shortNameOf returns undefined for an unknown ref", () => {
+  assert.equal(shortNameOf("refs/notes/foo"), undefined);
+});

--- a/packages/git-service/src/WorktreeProvider.ts
+++ b/packages/git-service/src/WorktreeProvider.ts
@@ -19,6 +19,9 @@ export interface WorktreeEntry {
 export interface WorktreeAddOptions extends GitRunOptions {
   /** Create a new branch (`-b <ref>`) instead of checking out an existing one. */
   newBranch?: boolean;
+  /** When `newBranch`, the ref the new branch starts from (`git worktree add
+   *  -b <ref> <path> <startPoint>`). Defaults to the current HEAD when unset. */
+  startPoint?: string;
 }
 
 export interface WorktreeRemoveOptions extends GitRunOptions {
@@ -53,6 +56,16 @@ export class WorktreeProvider {
   /**
    * `git worktree add [-b <ref>] <path> <ref>` — check out `ref` (or a new
    * branch named `ref`) into a fresh worktree at `path`.
+   *
+   * Upstream is deliberately NOT forced here: whether `-b <ref> <path>
+   * <startPoint>` sets the new branch to track its start point is decided by
+   * the user's `branch.autoSetupMerge` config. With the default `true` a
+   * differently-named branch started from a remote-tracking ref would
+   * auto-track the source — which is surprising (a bare `git push` then
+   * refuses under push.default=simple, or SyncOps pushes HEAD onto the
+   * source branch). JetBrains never tracks on "New Branch from <remote>",
+   * so GitStudio matches that by recommending `branch.autoSetupMerge simple`
+   * (track only when the names match) instead of baking `--no-track` in.
    */
   async add(
     path: string,
@@ -62,11 +75,32 @@ export class WorktreeProvider {
     const args = ["worktree", "add"];
     if (opts?.newBranch) {
       args.push("-b", ref, path);
+      if (opts.startPoint) {
+        args.push(opts.startPoint);
+      }
     } else {
       args.push(path, ref);
     }
     const r = await this.proc.run(args, { signal: opts?.signal });
     return { ok: r.code === 0, stderr: r.stderr };
+  }
+
+  /**
+   * The MAIN repository's working-tree root — the repo's "home" checkout, not
+   * this (possibly linked) worktree. `git worktree list` always reports the
+   * primary worktree first, so its path is the main checkout even when this
+   * runs from inside a linked worktree. Returns undefined when git can't report
+   * it. Used to name new worktree folders with a stable project prefix
+   * regardless of where the add is initiated from.
+   *
+   * NOT `rev-parse --absolute-git-common-dir`: Apple Git doesn't recognize that
+   * flag and `git rev-parse` then echoes the flag back as its own output
+   * (exit 0), turning the "project name" into ".". Worktree-list parsing has no
+   * such dependence on flag support.
+   */
+  async mainRoot(opts?: GitRunOptions): Promise<string | undefined> {
+    const entries = await this.list(opts);
+    return entries[0]?.path;
   }
 
   /** `git worktree remove [--force] <path>`. */

--- a/packages/git-service/src/WorktreeProvider.ts
+++ b/packages/git-service/src/WorktreeProvider.ts
@@ -22,6 +22,13 @@ export interface WorktreeAddOptions extends GitRunOptions {
   /** When `newBranch`, the ref the new branch starts from (`git worktree add
    *  -b <ref> <path> <startPoint>`). Defaults to the current HEAD when unset. */
   startPoint?: string;
+  /** When `newBranch`, suppress the new branch tracking its start point
+   *  (`--no-track`). Pass it whenever the branch's name differs from the start
+   *  point's short name: under git's default `branch.autoSetupMerge=true` a
+   *  `-b foo <path> origin/feature` would otherwise auto-track origin/feature,
+   *  and GitStudio's push then targets that remote branch. This implements
+   *  `branch.autoSetupMerge=simple` semantics ourselves. */
+  noTrack?: boolean;
 }
 
 export interface WorktreeRemoveOptions extends GitRunOptions {
@@ -57,15 +64,13 @@ export class WorktreeProvider {
    * `git worktree add [-b <ref>] <path> <ref>` — check out `ref` (or a new
    * branch named `ref`) into a fresh worktree at `path`.
    *
-   * Upstream is deliberately NOT forced here: whether `-b <ref> <path>
-   * <startPoint>` sets the new branch to track its start point is decided by
-   * the user's `branch.autoSetupMerge` config. With the default `true` a
-   * differently-named branch started from a remote-tracking ref would
-   * auto-track the source — which is surprising (a bare `git push` then
-   * refuses under push.default=simple, or SyncOps pushes HEAD onto the
-   * source branch). JetBrains never tracks on "New Branch from <remote>",
-   * so GitStudio matches that by recommending `branch.autoSetupMerge simple`
-   * (track only when the names match) instead of baking `--no-track` in.
+   * A new branch's upstream is decided HERE, not left to the user's
+   * `branch.autoSetupMerge`: git's default (`true`) makes a differently-named
+   * branch started from a remote-tracking ref auto-track it, and GitStudio's
+   * push then targets that remote branch — a commit the user never asked for.
+   * So `noTrack` should be set whenever the new branch's name differs from the
+   * start point's short name, keeping tracking only when the names match (the
+   * `simple` semantics, and what JetBrains' "New Branch from remote" does).
    */
   async add(
     path: string,
@@ -77,6 +82,9 @@ export class WorktreeProvider {
       args.push("-b", ref, path);
       if (opts.startPoint) {
         args.push(opts.startPoint);
+      }
+      if (opts.noTrack) {
+        args.push("--no-track");
       }
     } else {
       args.push(path, ref);

--- a/packages/git-service/test/worktree.test.ts
+++ b/packages/git-service/test/worktree.test.ts
@@ -120,3 +120,49 @@ test("parseWorktreePorcelain handles bare, detached, locked, and prunable", () =
   assert.equal(parsed[3].prunable, true);
   assert.equal(parsed[3].branch, "gone");
 });
+
+
+test("a differently-named branch from a remote start point gets no upstream unless told", async () => {
+  // A remote-tracking ref to start from. The hermetic env (test/hermetic.ts)
+  // blanks global config, so git's default branch.autoSetupMerge=true applies —
+  // exactly the situation WorktreeProvider.add()'s noTrack exists for.
+  const remoteDir = mkdtempSync(join(tmpdir(), "gitstudio-remote-"));
+  git(["init", "--bare", remoteDir]);
+  git(["remote", "add", "origin", remoteDir]);
+  git(["push", "-u", "origin", "main"]);
+  const paths: string[] = [];
+  try {
+    const noTrackPath = mkdtempSync(join(tmpdir(), "gitstudio-wt-notrack-"));
+    paths.push(noTrackPath);
+    rmSync(noTrackPath, { recursive: true, force: true }); // git wants a fresh path
+    const added = await ctx.worktrees.add(noTrackPath, "my-experiment", {
+      newBranch: true,
+      startPoint: "refs/remotes/origin/main",
+      noTrack: true,
+    });
+    assert.ok(added.ok, added.stderr);
+    // no upstream configured — a push would otherwise target origin/main.
+    assert.throws(() => git(["config", "--get", "branch.my-experiment.remote"]));
+
+    // Control: without noTrack, git's default tracks the differently-named
+    // branch — which is why callers must decide noTrack themselves.
+    const trackPath = mkdtempSync(join(tmpdir(), "gitstudio-wt-track-"));
+    paths.push(trackPath);
+    rmSync(trackPath, { recursive: true, force: true });
+    const control = await ctx.worktrees.add(trackPath, "control-track", {
+      newBranch: true,
+      startPoint: "refs/remotes/origin/main",
+    });
+    assert.ok(control.ok, control.stderr);
+    assert.equal(git(["config", "--get", "branch.control-track.remote"]).trim(), "origin");
+    assert.equal(
+      git(["config", "--get", "branch.control-track.merge"]).trim(),
+      "refs/heads/main",
+    );
+  } finally {
+    for (const p of paths) {
+      rmSync(p, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+    }
+    rmSync(remoteDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  }
+});


### PR DESCRIPTION
- "New Worktree" now offers local branches, remote branches, and tags. A
  remote/tag ref can be checked out directly (detached) or used as the
  start point of a new named branch.
- The branch menu's "New Worktree from '<branch>'" now runs the same two-step
  flow (checkout direct / new named branch) instead of creating immediately.
- New setting `gitstudio.worktrees.prefixWithProjectName` (default false):
  worktree folder becomes `<project>-<leaf>` instead of `<leaf>`, where
  `<project>` is the main repository's folder name (resolved from
  `git worktree list`, so the prefix is stable from any linked worktree and
  never compounds).

Behavior notes:
- Remote/tag checkouts are detached HEAD.
- Upstream tracking follows the user's `branch.autoSetupMerge` (not forced),
  matching JetBrains' "New Branch from remote".

API:
- `WorktreeProvider.add()` gains an optional `startPoint` (no behavior change
  when unset).
- `WorktreeProvider.mainRoot()` new: main checkout path from `git worktree list`.

Follow-up:
- `origin/HEAD` still shows in the worktrees picker.