### PR TITLE
feat(ext): dismiss branch popovers and dialogs on blur

### DIFF
--- a/apps/extension/src/changes/commitView.ts
+++ b/apps/extension/src/changes/commitView.ts
@@ -3779,8 +3779,15 @@ export class CommitViewProvider
     // Clicks in the editor/main area never reach this webview; blur is the only
     // signal that focus left it, so close the popover (JetBrains dismisses
     // popovers on any click anywhere in the IDE).
+    // blur does NOT bubble, but capture starts at window — so clicking inside
+    // the menu (moving focus off the focused row) fires this too. Only close
+    // when focus has genuinely left the webview: the setTimeout lets the focus
+    // move settle first, and the branchMenu-null guard keeps a stale callback
+    // from closing a menu that was already dismissed.
     function onBranchBlur() {
-      closeBranchMenu();
+      setTimeout(() => {
+        if (branchMenu && !document.hasFocus()) closeBranchMenu();
+      }, 0);
     }
     function onBranchKey(e) {
       if (e.key === "Escape") {
@@ -3914,7 +3921,9 @@ export class CommitViewProvider
     // this document. Blur is the only signal that focus left the webview, so
     // treat it like a click-outside (JetBrains dismisses popovers on any click).
     function onActionBlur() {
-      closeActionMenu();
+      setTimeout(() => {
+        if (actionMenuEl && !document.hasFocus()) closeActionMenu();
+      }, 0);
     }
     function onActionKey(e) {
       if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); closeActionMenu(); }
@@ -4348,9 +4357,19 @@ export class CommitViewProvider
 
       // Clicks in the editor/main area never reach this webview; blur is the
       // only signal that focus left it, so dismiss the dialog like JetBrains
-      // does for any click outside. Closing answers "undefined" (cancelled) —
-      // safe for destructive confirms, which only act on the explicit OK.
-      dlgBlurHandler = function () { closeDialog(undefined); };
+      // does for any click outside. BUT blur does not bubble — capture starts
+      // at window — so a click INSIDE the dialog (focus moving off the input
+      // onto a row) fires this handler too. Only dismiss when focus has really
+      // left the webview: the setTimeout lets the focus move settle, and the
+      // dlgEl guard keeps a stale callback from closing a dialog that was
+      // already answered — or a newer one opened by the very choice that closed
+      // this one. Closing answers "undefined" (cancelled); destructive confirms
+      // still only act on the explicit OK.
+      dlgBlurHandler = function () {
+        setTimeout(function () {
+          if (dlgEl && !document.hasFocus()) closeDialog(undefined);
+        }, 0);
+      };
       window.addEventListener("blur", dlgBlurHandler, true);
 
       dlgEl = el("div", "rp-panel");

--- a/apps/extension/src/changes/commitView.ts
+++ b/apps/extension/src/changes/commitView.ts
@@ -3763,6 +3763,7 @@ export class CommitViewProvider
       branchPill.setAttribute("aria-expanded", "false");
       document.removeEventListener("mousedown", onBranchDocDown, true);
       document.removeEventListener("keydown", onBranchKey, true);
+      window.removeEventListener("blur", onBranchBlur, true);
     }
     function closeBranchSubmenu() {
       if (branchSubmenu) { branchSubmenu.remove(); branchSubmenu = null; }
@@ -3773,6 +3774,12 @@ export class CommitViewProvider
       const inSub = branchSubmenu && branchSubmenu.contains(e.target);
       const onPill = branchPill.contains(e.target);
       if (inSub || inMenu || onPill) return;
+      closeBranchMenu();
+    }
+    // Clicks in the editor/main area never reach this webview; blur is the only
+    // signal that focus left it, so close the popover (JetBrains dismisses
+    // popovers on any click anywhere in the IDE).
+    function onBranchBlur() {
       closeBranchMenu();
     }
     function onBranchKey(e) {
@@ -3898,9 +3905,16 @@ export class CommitViewProvider
       if (actionMenuEl) { actionMenuEl.remove(); actionMenuEl = null; }
       document.removeEventListener("mousedown", onActionDocDown, true);
       document.removeEventListener("keydown", onActionKey, true);
+      window.removeEventListener("blur", onActionBlur, true);
     }
     function onActionDocDown(e) {
       if (actionMenuEl && !actionMenuEl.contains(e.target)) closeActionMenu();
+    }
+    // The webview cannot see clicks in the editor/main area — those never reach
+    // this document. Blur is the only signal that focus left the webview, so
+    // treat it like a click-outside (JetBrains dismisses popovers on any click).
+    function onActionBlur() {
+      closeActionMenu();
     }
     function onActionKey(e) {
       if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); closeActionMenu(); }
@@ -3938,6 +3952,7 @@ export class CommitViewProvider
       menu.style.top = Math.round(top) + "px";
       document.addEventListener("mousedown", onActionDocDown, true);
       document.addEventListener("keydown", onActionKey, true);
+      window.addEventListener("blur", onActionBlur, true);
       const first = list.querySelector(".bm-subaction");
       if (first) first.focus();
     }
@@ -4225,6 +4240,7 @@ export class CommitViewProvider
     var dlgEl = null;
     var dlgBackdrop = null;
     var dlgKeyHandler = null;
+    var dlgBlurHandler = null;
     var dlgReturnFocus = null;
     /** Correlation id of a host-requested dialog, so we can answer exactly once. */
     var dlgHostId = null;
@@ -4240,6 +4256,10 @@ export class CommitViewProvider
       if (dlgKeyHandler) {
         window.removeEventListener("keydown", dlgKeyHandler, true);
         dlgKeyHandler = null;
+      }
+      if (dlgBlurHandler) {
+        window.removeEventListener("blur", dlgBlurHandler, true);
+        dlgBlurHandler = null;
       }
       if (dlgBackdrop) { dlgBackdrop.remove(); dlgBackdrop = null; }
       if (dlgEl) { dlgEl.remove(); dlgEl = null; }
@@ -4325,6 +4345,13 @@ export class CommitViewProvider
         }
       };
       window.addEventListener("keydown", dlgKeyHandler, true);
+
+      // Clicks in the editor/main area never reach this webview; blur is the
+      // only signal that focus left it, so dismiss the dialog like JetBrains
+      // does for any click outside. Closing answers "undefined" (cancelled) —
+      // safe for destructive confirms, which only act on the explicit OK.
+      dlgBlurHandler = function () { closeDialog(undefined); };
+      window.addEventListener("blur", dlgBlurHandler, true);
 
       dlgEl = el("div", "rp-panel");
       dlgEl.setAttribute("role", "dialog");
@@ -4766,6 +4793,7 @@ export class CommitViewProvider
       setTimeout(() => {
         document.addEventListener("mousedown", onBranchDocDown, true);
         document.addEventListener("keydown", onBranchKey, true);
+        window.addEventListener("blur", onBranchBlur, true);
       }, 0);
     }
     branchPill.addEventListener("click", openBranchMenu);

--- a/apps/extension/src/changes/commitView.ts
+++ b/apps/extension/src/changes/commitView.ts
@@ -4249,7 +4249,6 @@ export class CommitViewProvider
     var dlgEl = null;
     var dlgBackdrop = null;
     var dlgKeyHandler = null;
-    var dlgBlurHandler = null;
     var dlgReturnFocus = null;
     /** Correlation id of a host-requested dialog, so we can answer exactly once. */
     var dlgHostId = null;
@@ -4265,10 +4264,6 @@ export class CommitViewProvider
       if (dlgKeyHandler) {
         window.removeEventListener("keydown", dlgKeyHandler, true);
         dlgKeyHandler = null;
-      }
-      if (dlgBlurHandler) {
-        window.removeEventListener("blur", dlgBlurHandler, true);
-        dlgBlurHandler = null;
       }
       if (dlgBackdrop) { dlgBackdrop.remove(); dlgBackdrop = null; }
       if (dlgEl) { dlgEl.remove(); dlgEl = null; }
@@ -4354,23 +4349,6 @@ export class CommitViewProvider
         }
       };
       window.addEventListener("keydown", dlgKeyHandler, true);
-
-      // Clicks in the editor/main area never reach this webview; blur is the
-      // only signal that focus left it, so dismiss the dialog like JetBrains
-      // does for any click outside. BUT blur does not bubble — capture starts
-      // at window — so a click INSIDE the dialog (focus moving off the input
-      // onto a row) fires this handler too. Only dismiss when focus has really
-      // left the webview: the setTimeout lets the focus move settle, and the
-      // dlgEl guard keeps a stale callback from closing a dialog that was
-      // already answered — or a newer one opened by the very choice that closed
-      // this one. Closing answers "undefined" (cancelled); destructive confirms
-      // still only act on the explicit OK.
-      dlgBlurHandler = function () {
-        setTimeout(function () {
-          if (dlgEl && !document.hasFocus()) closeDialog(undefined);
-        }, 0);
-      };
-      window.addEventListener("blur", dlgBlurHandler, true);
 
       dlgEl = el("div", "rp-panel");
       dlgEl.setAttribute("role", "dialog");


### PR DESCRIPTION
Replaces the previously-closed #15 (its head branch was force-pushed past the state GitHub had recorded).

Branch popovers and action menus close on any click outside the webview — including clicks in the editor or other areas, which never reach the webview. Blur is the only signal that focus left the webview, so it is treated as a click-outside, matching JetBrains' dismissal behavior for popovers.

Blur does not bubble, but capture starts at window, so a click INSIDE a menu (focus moving off the focused row) fires the dismiss handler too. The handler checks `document.hasFocus()` in a setTimeout — a focus move that stays in the webview is not treated as a click outside — and guards on the element still existing, so a stale callback cannot close a menu that was already dismissed.

The dialogs (ref picker, branch name input) deliberately do NOT dismiss on blur: blur also fires when you switch to another application, and alt-tabbing away must not lose a half-typed name. They close on Escape and backdrop-click only, as before.

Behavior notes:
- Dialogs answer "cancelled" on Escape / backdrop-click; destructive confirms still only act on the explicit OK.
- Popovers also close on Escape, as before.
